### PR TITLE
Stop parsing upstream allowlist

### DIFF
--- a/bin/parse_source_data
+++ b/bin/parse_source_data
@@ -2,7 +2,6 @@
 
 lists = {
     'blocklist': 'source_data/disposable_email_blocklist.conf',
-    'allowlist': 'source_data/allowlist.conf',
 }
 
 
@@ -20,5 +19,6 @@ print("\n\n".join([parse_list(*args) for args in sorted(lists.items())]))
 
 print("""
 # For backwards compatibility
+allowlist = set()
 locals()['tsilkcalb'[::-1]] = blocklist
 locals()['tsiletihw'[::-1]] = allowlist""")


### PR DESCRIPTION
Due to https://github.com/disposable-email-domains/disposable-email-domains/pull/936.